### PR TITLE
blocked ability to post the same user to store relationship

### DIFF
--- a/app/graphql/mutations/create_user_store.rb
+++ b/app/graphql/mutations/create_user_store.rb
@@ -7,15 +7,19 @@ class Mutations::CreateUserStore < Mutations::BaseMutation
   
   def resolve(store_id:, user_id:)
     user_store = UserStore.new(store_id: store_id, user_id: user_id)
-
-    if user_store.save
+    if (UserStore.any? { |user_store| user_store.user_id == user_id.to_i } && UserStore.any? { |user_store| user_store.store_id == store_id.to_i }) 
+      {
+        user_store: nil,
+        errors: []
+      }
+    elsif user_store.save
       {
         user_store: user_store,
         errors: []
-      }
+      }  
     else
       {
-        user: nil,
+        user_store: nil,
         errors: user_store.errors.full_messages
       }
     end


### PR DESCRIPTION
# Describe Your Changes Below and say where to start in the files changed. Also say why you made this change.
This change was requested by the FE. This change disables the ability to create a repeated relationship between the user and a store. I added some conditional logic into the mutation for creating a user store so that the code checks if the userstore already exists. If it does, then the return contains and error and the duplicate userStore is not created. I also found a couple blank lines of code that I deleted along the way.

# Pull Request
- [x] New feature (adds functionality)
- [ ] Refactor
- [x] Fix Bugs
- [x] Add Testing
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):


# Please describe the tests that you ran to verify your changes.
- [x] I tested my changes in the browser
- [x] I tested my changes with SimpleCov

## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
